### PR TITLE
TTL event readout from OpenEphys dataset

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,2 +1,3 @@
 _external_assets
 _assets
+**/datasets

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -26,6 +26,7 @@ Here we provide number of example scripts using `MiV` tools. Some examples provi
 
    sample_datasets
    data_structure/hdf5_based_data_format
+   read_TTL_events
 
 Indices and tables
 ==================

--- a/docs/guide/read_TTL_events.md
+++ b/docs/guide/read_TTL_events.md
@@ -1,0 +1,59 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.14.1
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
+# Read TTL Events in OpenEphys Data
+
+```{code-cell} ipython3
+:tags: [hide-cell]
+
+from miv.datasets.ttl_events import load_data
+```
+
+## Load example dataset
+
+TTL event are compose of five data types: states, full_words, timestamps, sampling rate, and initial state.
+
+- The details of what each data represent is described [here](https://open-ephys.github.io/gui-docs/User-Manual/Recording-data/Binary-format.html#events).
+- The API documentation is [here](file:///Users/skim0119/github/MiV-OS/docs/_build/html/api/io.html#miv.io.binary.apply_channel_mask).
+
+> Note: The timestamps data are already synchronized with other recording streams. To match the time, make sure to turn off `start_at_zero` when loading the signal.
+
+```{code-cell} ipython3
+:tags: [hide-cell]
+
+datasets = load_data()
+```
+
+```{code-cell} ipython3
+data = datasets[0]
+states, full_words, timestamps, sampling_rate, initial_state = data.load_ttl_event()
+```
+
+## Visualize TTL Events
+
+```{code-cell} ipython3
+:tags: [hide-cell]
+
+import numpy as np
+import matplotlib.pyplot as plt
+```
+
+```{code-cell} ipython3
+on = timestamps[states == 1]
+off = timestamps[states == -1]
+
+for start, end in zip(on, off):
+    plt.axvspan(start, end, alpha=0.4, color='red')
+plt.title("TTL ON/OFF Events")
+plt.xlabel("time (s)")
+```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,12 +1,9 @@
-.. MiV-OS documentation master file, created by
-   sphinx-quickstart on Thu Mar 24 23:35:49 2022.
-
-MiV-OS documentation!
-=====================
+Mind-in-Vitro Open Software
+===========================
 
 **MiV-OS** is a *free* and *open-source* software project for the post-processing and analysis of **mind-in-vitro** project.
 
-The software is developed and maintained by the Gazzola Lab at the University of Illinois at Urbana-Champaign. For more information on the projects and what we work on, visit our `website <https://mattia-lab.com>`_.
+The software is developed and maintained by the Gazzola Lab at the University of Illinois at Urbana-Champaign. For more information on the projects and what we work on, visit our `website <https://mindinvitro.illinois.edu>`_.
 
 Installation Instruction
 ------------------------

--- a/miv/datasets/ttl_events.py
+++ b/miv/datasets/ttl_events.py
@@ -1,0 +1,74 @@
+__doc__ = """Sample TTL-input signal readout."""
+__all__ = ["load_data"]
+
+import gzip
+import os
+
+import numpy as np
+
+from miv.datasets.utils import get_file
+from miv.io import DataManager
+
+
+def load_data():  # pragma: no cover
+    """
+    Loads the sample TTL data readout. `Direct Download <https://uofi.box.com/shared/static/9llg11ods9iejdt2omjwjosbsxb5ui10.zip>`_
+
+    Total size: 17.4 kB (compressed)
+
+    File hash: a4314442fd9eba4377934c5766971ba1e04f079b7e615b8fb033992323afeb3f
+
+    Examples
+    --------
+        >>> from miv.datasets.ttl_events import load_data
+        >>> experiments: miv.io.DataManager = load_data()
+        datasets/ttl_recording/sample_event_recording
+            0: <miv.io.data.Data object at 0x7fec71c99fa0>
+               └── Record Node 101/experiment1/recording1
+
+
+    Notes
+    -----
+    All experiment are 1 minute long, 30k Hz recording of optogenetic
+    neuron cells over 64 channels MEA. Dataset includes 1 spontaneous
+    recording and 4 stimulated recording.
+
+    Spontaneous recording is the recording over 1 minute period without
+    external stimulation. The purpose was to measure the baseline mean-
+    firing rate.
+
+    Stimulation was done by LED light. Over 1 minute (60 seconds) period,
+    6 stimulation was done with 10 seconds of intervals. For each stimulation,
+    LED light was shined over 1 seconds, followed by remaining 9 seconds
+    of rest (without light).
+
+    Containing experiments:
+
+    * experiment0: TTL recording
+
+    Returns
+    -------
+    dataset: miv.io.DataManager
+
+    Examples
+    --------
+        >>> from miv import datasets
+        >>> experiments: miv.io.DataManager = datasets.ttl_events.load_data()
+
+    """
+
+    subdir = "ttl_recording"
+    base_url = "https://uofi.box.com/shared/static/w3cylplece450up6t6h53vuq93t98q2k.zip"
+    file = "sample_event_recording.zip"
+    file_hash = "a4314442fd9eba4377934c5766971ba1e04f079b7e615b8fb033992323afeb3f"
+
+    path = get_file(
+        file_url=base_url,
+        directory=subdir,
+        fname=file,
+        file_hash=file_hash,
+        archive_format="zip",
+    )
+    experiment = DataManager(path)
+    experiment.tree()
+    return experiment

--- a/miv/io/data.py
+++ b/miv/io/data.py
@@ -37,7 +37,7 @@ from glob import glob
 import matplotlib.pyplot as plt
 import numpy as np
 
-from miv.io.binary import load_continuous_data, load_recording
+from miv.io.binary import load_continuous_data, load_recording, load_ttl_event
 from miv.signal.filter.protocol import FilterProtocol
 from miv.signal.spike.protocol import SpikeDetectionProtocol
 from miv.statistics import firing_rates
@@ -157,6 +157,12 @@ class Data:
         finally:
             del timestamps
             del signal
+
+    def load_ttl_event(self):
+        """
+        Load TTL event data if data contains. Detail implementation is :func:`here <miv.io.binary.load_ttl_event>`.
+        """
+        return load_ttl_event(self.data_path)
 
     def set_channel_mask(self, channel_id: Iterable[int]):
         """

--- a/miv/io/data.py
+++ b/miv/io/data.py
@@ -122,9 +122,15 @@ class Data:
         plt.savefig(filepath, **savefig_kwargs)
 
     @contextmanager
-    def load(self):
+    def load(self, start_at_zero: bool = False):
         """
         Context manager for loading data instantly.
+
+        Parameters
+        ----------
+        start_at_zero : bool
+            If set to True, time first timestamps will be shifted to zero. To achieve synchronized
+            timestamps with other recordings/events, set this to False.
 
         Examples
         --------
@@ -151,7 +157,7 @@ class Data:
             raise FileNotFoundError("Data directory does not have all necessary files.")
         try:
             signal, timestamps, sampling_rate = load_recording(
-                self.data_path, self.masking_channel_set
+                self.data_path, self.masking_channel_set, start_at_zero=start_at_zero
             )
             yield signal, timestamps, sampling_rate
         finally:

--- a/miv/visualization/waveform.py
+++ b/miv/visualization/waveform.py
@@ -53,7 +53,7 @@ def extract_waveforms(
         Return stacks of spike cutout; shape(n_spikes, width).
 
     """
-    if channel:
+    if channel is not None:
         signal = signal[:, channel]
         spikestamps = spikestamps[channel]
 

--- a/miv/visualization/waveform.py
+++ b/miv/visualization/waveform.py
@@ -24,7 +24,7 @@ from miv.typing import SignalType, SpikestampsType
 def extract_waveforms(
     signal: SignalType,
     spikestamps: SpikestampsType,
-    channel: int,
+    channel: Optional[int],
     sampling_rate: float,
     pre: pq.Quantity = 0.001 * pq.s,
     post: pq.Quantity = 0.002 * pq.s,
@@ -38,8 +38,8 @@ def extract_waveforms(
         The signal as a 2-dimensional numpy array (length, num_channel)
     spikestamps : SpikestampsType
         The sample index of all spikes as a 1-dim numpy array
-    channel : int
-        Interested channel
+    channel : Optional[int]
+        Interested channel. If None, assume signal and spikestamps are single channel.
     sampling_rate : float
         The sampling frequency in Hz
     pre : pq.Quantity
@@ -53,9 +53,9 @@ def extract_waveforms(
         Return stacks of spike cutout; shape(n_spikes, width).
 
     """
-    # TODO: Refactor this part
-    signal = signal[:, channel]
-    spikestamps = spikestamps[channel]
+    if channel:
+        signal = signal[:, channel]
+        spikestamps = spikestamps[channel]
 
     cutouts = []
     pre_idx = int(pre * sampling_rate)

--- a/tests/io/mock_data.py
+++ b/tests/io/mock_data.py
@@ -97,7 +97,7 @@ class MockDataGenerator:
 
         # Expected timestamps
         sampling_rate = 30000
-        expected_timestamps = (timestamps - np.pi) / sampling_rate
+        expected_timestamps = timestamps / sampling_rate
 
         return dirname, expected_data, expected_timestamps, sampling_rate
 


### PR DESCRIPTION
In an attempt to resolve #96, feature to read OpenEphys TTL input is added to `miv.io` module.

For detail, check [here](https://miv-os.readthedocs.io/en/feature-ttl_event/guide/read_TTL_events.html)