### PR TITLE
[Feature] Spike statistical filter

### DIFF
--- a/docs/api/_toctree/FilterAPI/miv.signal.events.waveform.ExtractWaveforms.rst
+++ b/docs/api/_toctree/FilterAPI/miv.signal.events.waveform.ExtractWaveforms.rst
@@ -1,6 +1,0 @@
-﻿miv.signal.events.waveform.ExtractWaveforms
-===========================================
-
-.. currentmodule:: miv.signal.events.waveform
-
-.. autoclass:: ExtractWaveforms

--- a/docs/api/signal.rst
+++ b/docs/api/signal.rst
@@ -15,17 +15,3 @@ Signal Filter
    ButterBandpass
    MedianFilter
    Notch
-
-
-Spike Waveform Extraction
-#########################
-
-.. currentmodule:: miv.visualization
-
-.. automodule:: miv.signal.events.waveform
-
-   .. autosummary::
-      :nosignatures:
-      :toctree: _toctree/FilterAPI
-
-      ExtractWaveforms

--- a/docs/guide/connectivity_network.md
+++ b/docs/guide/connectivity_network.md
@@ -45,7 +45,7 @@ Before we dive into connectivity analysis, it's important to ensure that the dat
 ```{code-cell} ipython3
 # Create operator modules:
 bandpass_filter: Operator = ButterBandpass(lowcut=300, highcut=3000, order=4, tag="bandpass")
-spike_detection: Operator = ThresholdCutoff(cutoff=4.0, use_mad=True, dead_time=0.002, tag="spikes")
+spike_detection: Operator = ThresholdCutoff(cutoff=4.0, dead_time=0.002, tag="spikes")
 
 data >> bandpass_filter >> spike_detection
 ```

--- a/docs/tutorial/signal_processing.md
+++ b/docs/tutorial/signal_processing.md
@@ -58,7 +58,7 @@ data: DataLoader = dataset[0]
 # Create operator modules:
 bandpass_filter: Operator = ButterBandpass(lowcut=300, highcut=3000, order=4)
 lfp_filter: Operator = ButterBandpass(highcut=3000, order=2, btype='lowpass')
-spike_detection: Operator = ThresholdCutoff(cutoff=4.0, use_mad=True, dead_time=0.002)
+spike_detection: Operator = ThresholdCutoff(cutoff=4.0, dead_time=0.002)
 ```
 
 In this code block, we are creating three different operator modules, namely `bandpass_filter`, `lfp_filter`, and `spike_detection`.

--- a/docs/tutorial/spike_cutout.md
+++ b/docs/tutorial/spike_cutout.md
@@ -47,7 +47,7 @@ We use `bandpass_filter` and the `spike_detection`, using the `ButterBandpass` a
 ```{code-cell} ipython3
 # Create operator modules:
 bandpass_filter: Operator = ButterBandpass(lowcut=300, highcut=3000, order=4, tag="bandpass")
-spike_detection: Operator = ThresholdCutoff(cutoff=4.0, use_mad=True, dead_time=0.002, tag="spikes")
+spike_detection: Operator = ThresholdCutoff(cutoff=4.0, dead_time=0.002, tag="spikes")
 ```
 
 We can assign a `tag` to each operator to label it and help visualize the processing steps later.
@@ -60,7 +60,7 @@ It requires a list of channels to extract the spikes from, which we can specify 
 We can also limit the number of spikes to plot using the `plot_n_spikes` parameter.
 
 ```{code-cell} ipython3
-from miv.signal.events import ExtractWaveforms
+from miv.signal.spike import ExtractWaveforms
 
 extract_waveforms: Operator = ExtractWaveforms(channels=[11, 26, 37, 50], plot_n_spikes=150)
 ```

--- a/docs/tutorial/spike_sorting.md
+++ b/docs/tutorial/spike_sorting.md
@@ -36,8 +36,7 @@ import matplotlib.pyplot as plt
 from miv.core.pipeline import Pipeline
 from miv.io.openephys import Data, DataManager
 from miv.signal.filter import ButterBandpass
-from miv.signal.spike import ThresholdCutoff
-from miv.signal.events import ExtractWaveforms
+from miv.signal.spike import ThresholdCutoff, ExtractWaveforms
 
 from miv.datasets.openephys_sample import load_data
 

--- a/miv/core/operator/operator.py
+++ b/miv/core/operator/operator.py
@@ -128,6 +128,9 @@ class OperatorMixin(BaseChainingMixin, BaseCallbackMixin):
         self.analysis_path = os.path.join(path, self.tag.replace(" ", "_"))
         self.cacher.cache_dir = os.path.join(self.analysis_path, ".cache")
 
+    def make_analysis_path(self):
+        os.makedirs(self.analysis_path, exist_ok=True)
+
     def receive(self) -> list[DataTypes]:
         return [node.output for node in self.iterate_upstream()]
 
@@ -160,6 +163,8 @@ class OperatorMixin(BaseChainingMixin, BaseCallbackMixin):
         if dry_run:
             print("Dry run: ", self.__class__.__name__)
             return
+        self.make_analysis_path()
         self._execute()
-        if not skip_plot:
+        cache_called = self.cacher.cache_called
+        if not skip_plot and not cache_called:
             self.plot(show=False, save_path=True, dry_run=dry_run)

--- a/miv/core/policy.py
+++ b/miv/core/policy.py
@@ -45,6 +45,7 @@ class VanillaRunner:
         if inputs is None:
             output = func()
         else:
+            # TODO: support kwargs
             output = func(*inputs)
         return output
 

--- a/miv/signal/events/__init__.py
+++ b/miv/signal/events/__init__.py
@@ -1,1 +1,0 @@
-from miv.signal.events.waveform import *

--- a/miv/signal/spike/__init__.py
+++ b/miv/signal/spike/__init__.py
@@ -2,3 +2,4 @@ from miv.signal.spike.detection import *
 from miv.signal.spike.protocol import *
 from miv.signal.spike.sorting import *
 from miv.signal.spike.waveform import *
+from miv.signal.spike.waveform_statistical_filter import *

--- a/miv/signal/spike/__init__.py
+++ b/miv/signal/spike/__init__.py
@@ -1,3 +1,4 @@
 from miv.signal.spike.detection import *
 from miv.signal.spike.protocol import *
 from miv.signal.spike.sorting import *
+from miv.signal.spike.waveform import *

--- a/miv/signal/spike/detection.py
+++ b/miv/signal/spike/detection.py
@@ -15,6 +15,7 @@ Code Example::
    ThresholdCutoff
    ExtractWaveforms
    WaveformAverage
+   WaveformStatisticalFilter
 
 """
 __all__ = ["ThresholdCutoff", "query_firing_rate_between"]

--- a/miv/signal/spike/detection.py
+++ b/miv/signal/spike/detection.py
@@ -13,6 +13,8 @@ Code Example::
 
    SpikeDetectionProtocol
    ThresholdCutoff
+   ExtractWaveforms
+   WaveformAverage
 
 """
 __all__ = ["ThresholdCutoff", "query_firing_rate_between"]
@@ -38,7 +40,7 @@ from miv.core.datatype import Signal, Spikestamps
 from miv.core.operator import OperatorMixin
 from miv.core.policy import InternallyMultiprocessing
 from miv.core.wrapper import wrap_cacher
-from miv.statistics import firing_rates
+from miv.statistics.spiketrain_statistics import firing_rates
 from miv.typing import SignalType, SpikestampsType, TimestampsType
 
 

--- a/miv/signal/spike/sorting.py
+++ b/miv/signal/spike/sorting.py
@@ -52,8 +52,8 @@ __all__ = [
     "SpikeSorting",
     "PCADecomposition",
     "PCAClustering",
-    # "WaveletDecomposition",
-    # "SuperParamagneticClustering",
+    "WaveletDecomposition",
+    "SuperParamagneticClustering",
 ]
 
 from typing import Any, Optional, Union
@@ -84,13 +84,13 @@ class SpikeSorting:
     """
     Spike sorting module.
     User can specify the method for feature extraction (e.g. WaveletDecomposition, PCADecomposition, etc)
-    and the method for clustering (e.g. MeanShift, KMeans, SuperParamagneticClustering, etc).
+    and the method for clustering (e.g. MeanShift, KMeans, etc).
 
 
     Examples
     --------
     >>> spike_sorting = SpikeSorting(
-    ...    feature_extractor=WaveletDecomposition(),
+    ...    feature_extractor=PCADecomposition(),
     ...    clustering_method=sklearn.cluster.MeanShift()
     ... )
 
@@ -126,7 +126,8 @@ class SuperParamagneticClustering:  # pragma : no cover
 
     """
 
-    pass
+    def __init__(self):
+        raise NotImplementedError
 
 
 class PCADecomposition:

--- a/miv/signal/spike/waveform.py
+++ b/miv/signal/spike/waveform.py
@@ -19,14 +19,13 @@ from scipy.signal import lfilter, savgol_filter
 from sklearn.decomposition import PCA
 from sklearn.mixture import GaussianMixture
 from sklearn.preprocessing import StandardScaler
+from tqdm import tqdm
 
 from miv.core.datatype import Signal, Spikestamps
 from miv.core.operator import OperatorMixin
 from miv.core.wrapper import wrap_generator_to_generator
 from miv.mea import MEAGeometryProtocol
 from miv.typing import SignalType, SpikestampsType
-
-from tqdm import tqdm
 
 
 @dataclass
@@ -98,7 +97,9 @@ class ExtractWaveforms(OperatorMixin):
             assert (
                 pre_idx + post_idx > 0
             ), "Set larger pre/post duration. pre+post duration must be more than 1/sampling_rate."
-            spikestamps_view = spikestamps.get_view(sig.get_start_time(), sig.get_end_time())
+            spikestamps_view = spikestamps.get_view(
+                sig.get_start_time(), sig.get_end_time()
+            )
             for ch in channels:
                 # Padding signal
                 spikestamp = spikestamps_view[ch]
@@ -166,7 +167,7 @@ class ExtractWaveforms(OperatorMixin):
 
             fig, ax = plt.subplots(figsize=(8, 5))
             for i in range(plot_n_spikes):
-                arr = cutout[:,i]
+                arr = cutout[:, i]
                 arr[np.isnan(arr)] = 0
                 ax.plot(
                     time,

--- a/miv/signal/spike/waveform_statistical_filter.py
+++ b/miv/signal/spike/waveform_statistical_filter.py
@@ -93,7 +93,7 @@ class WaveformStatisticalFilter(OperatorMixin):
             )
             number_of_outliers = indices.sum()
 
-            filtered_spiketrains.append(np.asarray(spiketrain)[indices])
+            filtered_spiketrains.append(np.asarray(spiketrain)[~indices])
             log.append(
                 (
                     channel,
@@ -103,6 +103,12 @@ class WaveformStatisticalFilter(OperatorMixin):
                 )
             )
 
+        self._log = log  # FIXME: Maybe better way to pass down the result
+
+        return filtered_spiketrains
+
+    def after_run_save_log(self, *args, **kwargs):
+        log = self._log
         # Save log in csv
         savepath = os.path.join(self.analysis_path, "filtered_statistics.csv")
         with open(savepath, "w", newline="") as csvfile:
@@ -112,5 +118,3 @@ class WaveformStatisticalFilter(OperatorMixin):
             )
             for row in log:
                 writer.writerow(row)
-
-        return filtered_spiketrains

--- a/miv/signal/spike/waveform_statistical_filter.py
+++ b/miv/signal/spike/waveform_statistical_filter.py
@@ -1,0 +1,116 @@
+__doc__ = """
+Module for filtering spiketrain based on waveform statistical properties.
+
+Motivated by _[1].
+
+[1]. Toosi R., et al. An automatic spike sorting algorithm based on adaptive spike detection and a mixture of skew-t distributions (2021).
+"""
+__all__ = ["WaveformStatisticalFilter"]
+
+from typing import Dict, Optional
+
+import csv
+import os
+from dataclasses import dataclass
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from miv.core.datatype import Signal, Spikestamps
+from miv.core.operator import OperatorMixin
+
+
+@dataclass
+class WaveformStatisticalFilter(OperatorMixin):
+    """
+    Filter spike train based on waveform statistical properties.
+
+    Mainly, the waveform that has a mean larger than 1.0 and standard deviation larger than 3.0.
+
+    .. code::
+
+        >>> filtered_signal = ButterBandpass(300, 3000, order=4)
+        >>> spiketrains = ThresholdCutoff(cutoff=4.0)
+        >>> waveform = ExtractWaveforms()
+
+        >>> filtered_signal >> spiketrains
+        >>> filtered_signal >> waveform; spiketrains >> waveform
+        >>> waveform >> statistical_filter; spiketrains >> statistical_filter
+
+        >>> Pipeline(statistical_filter).run()
+
+    Parameters
+    ----------
+    max_mean : float
+        The maximum mean of the waveform. (default: 1.0)
+    max_std : float
+        The maximum standard deviation of the waveform. (default: 3.0)
+    """
+
+    max_mean: float = 1.0
+    max_std: float = 3.0
+
+    tag: str = "waveform statistical filter"
+
+    def __post_init__(self):
+        super().__init__()
+
+    def __call__(
+        self, waveforms: Dict[int, Signal], spiketrains: Spikestamps
+    ) -> Spikestamps:
+        """
+        Parameters
+        ----------
+        waveforms : Dict[int, Signal]
+            The waveforms of each channel.
+        spiketrains : Spikestamps
+            The spiketrains of each channel.
+
+        Returns
+        -------
+        Spikestamps
+            The filtered spiketrains of each channel.
+        """
+
+        filtered_spiketrains = Spikestamps()
+        total_spikecounts = spiketrains.get_count()
+        log = []
+        for channel in range(spiketrains.number_of_channels):
+            if channel not in waveforms:
+                filtered_spiketrains.append(np.array([]))
+                continue
+            waveform = waveforms[channel]
+            spiketrain = spiketrains[channel]
+            total_spikecount = total_spikecounts[channel]
+
+            spike_mean = np.mean(waveform.data, axis=waveform._SIGNALAXIS)
+            spike_std = np.std(waveform.data, axis=waveform._SIGNALAXIS)
+
+            indices = (
+                (spike_std > self.max_std)
+                | (spike_mean > self.max_mean)
+                | (spike_mean < -self.max_mean)
+            )
+            number_of_outliers = indices.sum()
+
+            filtered_spiketrains.append(np.asarray(spiketrain)[indices])
+            log.append(
+                (
+                    channel,
+                    total_spikecount,
+                    number_of_outliers,
+                    number_of_outliers / total_spikecount,
+                )
+            )
+
+        # Save log in csv
+        savepath = os.path.join(self.analysis_path, "filtered_statistics.csv")
+        with open(savepath, "w", newline="") as csvfile:
+            writer = csv.writer(csvfile)
+            writer.writerow(
+                ["channel", "total spikecount", "number of filtered outliers", "ratio"]
+            )
+            for row in log:
+                writer.writerow(row)
+
+        return filtered_spiketrains

--- a/miv/statistics/signal_statistics.py
+++ b/miv/statistics/signal_statistics.py
@@ -2,7 +2,7 @@ __all__ = ["signal_to_noise", "spike_amplitude_to_background_noise"]
 
 import numpy as np
 
-from miv.signal.events.waveform import ExtractWaveforms
+from miv.signal.spike.waveform import ExtractWaveforms
 from miv.typing import SignalType, SpikestampsType
 
 

--- a/tests/signal/test_waveform.py
+++ b/tests/signal/test_waveform.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from miv.core.datatype import Signal, Spikestamps
-from miv.signal.events import ExtractWaveforms
+from miv.signal.spike import ExtractWaveforms
 
 
 @pytest.fixture(name="mock_signal_for_waveform")

--- a/tests/spike/test_spike_detection.py
+++ b/tests/spike/test_spike_detection.py
@@ -14,12 +14,8 @@ def threshold_cutoff():
 def test_compute_spike_threshold(threshold_cutoff):
     signal = np.array([1, 2, 3, 4, 5])
     cutoff = 3.0
-    use_mad = True
     expected_output = -np.median(np.absolute(signal)) / 0.6745 * cutoff
-    assert (
-        threshold_cutoff._compute_spike_threshold(signal, cutoff, use_mad)
-        == expected_output
-    )
+    assert threshold_cutoff._compute_spike_threshold(signal, cutoff) == expected_output
 
 
 def test_detect_threshold_crossings(threshold_cutoff):

--- a/tests/spike/test_waveform_statistical_filter.py
+++ b/tests/spike/test_waveform_statistical_filter.py
@@ -1,0 +1,79 @@
+import numpy as np
+import pytest
+
+from miv.core.datatype import Signal, Spikestamps
+from miv.signal.spike import WaveformStatisticalFilter
+
+
+def test_waveform_statistical_filter_normal():
+    wave = np.zeros(10).reshape([10, 1])
+    time = np.linspace(0, 1, 10)
+    rate = 1.0 / 10
+    testing_waveform = {0: Signal(wave, time, rate)}
+
+    testing_spiketrains = Spikestamps()
+    testing_spiketrains.append(np.array([0.5]))
+
+    # Testing
+    wsf = WaveformStatisticalFilter()
+    result = wsf(testing_waveform, testing_spiketrains)
+
+    np.testing.assert_allclose(result.data, [[0.5]])
+    np.testing.assert_allclose(result.get_count(), [1])
+
+
+def test_waveform_statistical_filter_mean_over():
+    wave = np.zeros(10).reshape([10, 1]) + 5
+    time = np.linspace(0, 1, 10)
+    rate = 1.0 / 10
+    testing_waveform = {0: Signal(wave, time, rate)}
+
+    testing_spiketrains = Spikestamps()
+    testing_spiketrains.append(np.array([0.5]))
+
+    # Testing
+    wsf = WaveformStatisticalFilter()
+    result = wsf(testing_waveform, testing_spiketrains)
+
+    np.testing.assert_allclose(result.get_count(), [0])
+
+
+def test_waveform_statistical_filter_std_over():
+    wave = (np.random.random(10) * 20).reshape([10, 1])
+    time = np.linspace(0, 1, 10)
+    rate = 1.0 / 10
+    testing_waveform = {0: Signal(wave, time, rate)}
+
+    testing_spiketrains = Spikestamps()
+    testing_spiketrains.append(np.array([0.5]))
+
+    # Testing
+    wsf = WaveformStatisticalFilter()
+    result = wsf(testing_waveform, testing_spiketrains)
+
+    np.testing.assert_allclose(result.get_count(), [0])
+
+
+def test_waveform_statistical_filter_mix():
+    testing_waveform = {}
+
+    wave1 = np.random.random(10) * 5
+    wave2 = np.zeros(10)
+    wave3 = np.zeros(10) + 10
+    wave4 = np.zeros(10) - 3
+    wave = np.vstack(
+        [wave1, wave2, wave3, wave4]
+    ).T  # TODO: remove T if axis change for signal
+    time = np.linspace(0, 1, 10)
+    rate = 1.0 / 10
+    testing_waveform[0] = Signal(wave, time, rate)
+
+    testing_spiketrains = Spikestamps()
+    testing_spiketrains.append(np.array([0.5, 1.0, 1.5, 2.0]))
+
+    # Testing
+    wsf = WaveformStatisticalFilter(max_mean=5, max_std=1)
+    result = wsf(testing_waveform, testing_spiketrains)
+
+    np.testing.assert_allclose(result.data, [[1.0, 2.0]])
+    np.testing.assert_allclose(result.get_count(), [2])


### PR DESCRIPTION
# Description

> Simple statistical filter for spike sorting.
> Can be adapted to existing ThresholdCutoff and Waveform analysis:

```py
filtered_signal = ButterBandpass(300, 3000, order=4)
spiketrains = ThresholdCutoff(cutoff=4.0)
waveform = ExtractWaveforms()
filtered_signal >> spiketrains
filtered_signal >> waveform; spiketrains >> waveform
waveform >> statistical_filter; spiketrains >> statistical_filter
Pipeline(statistical_filter).run()
```

[paper link](https://www.nature.com/articles/s41598-021-93088-w)

### Minor Fixes:

- Spike threshold uses median always, and removed option to use std.
- `Waveform` analysis is now under `miv.signal.spike` (previously it was `miv.signal.events`)
- Cacher includes the variable `cache_called` which indicates if previous run called cache.
- Plotting will be ignored if run configuration is same, or called from cache.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `make test`
- [x] New tests implementation

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings/errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been addressed and published in downstream modules
- [x] There are no other PR/Issues that is blocking this PR.
